### PR TITLE
Ref and Branch magic var

### DIFF
--- a/pkg/job/core.go
+++ b/pkg/job/core.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -52,7 +53,7 @@ func (cj *coreJob) GetTree() error {
 	return nil
 }
 
-func (cj *coreJob) LoadSpec() error {
+func (cj *coreJob) LoadSpec(refName string) error {
 	tree, err := cj.client.GetTree(cj.commit.Sha, cj.repo)
 	if err != nil {
 		return err
@@ -71,6 +72,12 @@ func (cj *coreJob) LoadSpec() error {
 		return err
 	}
 	cj.spec.SetMetaVar("__commit__", cj.commit.Sha)
+	cj.spec.SetMetaVar("__ref__", refName)
+
+	refComponents := strings.Split(refName, "/")
+	branchName := refComponents[len(refComponents)-1]
+	cj.spec.SetMetaVar("__branch__", branchName)
+
 	return nil
 }
 

--- a/pkg/job/core.go
+++ b/pkg/job/core.go
@@ -72,6 +72,7 @@ func (cj *coreJob) LoadSpec(refName string) error {
 		return err
 	}
 	cj.spec.SetMetaVar("__commit__", cj.commit.Sha)
+	refName = strings.ReplaceAll(refName, "\"", "")
 	cj.spec.SetMetaVar("__ref__", refName)
 
 	refComponents := strings.Split(refName, "/")

--- a/pkg/job/pushjob.go
+++ b/pkg/job/pushjob.go
@@ -70,7 +70,7 @@ func (p *PushJob) Run(ctx context.Context) {
 
 	p.Log.Metadata(map[string]interface{}{"process": "PushJob"})
 	p.Log.Info("loading test specifications")
-	err = cj.LoadSpec()
+	err = cj.LoadSpec(p.GetRefName())
 	if err != nil {
 		p.Log.Metadata(map[string]interface{}{"process": "PushJob", "error": err})
 		p.Log.Error("failed to load spec")

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -52,8 +52,6 @@ func (s *Spec) AfterScriptCmd(ctx context.Context, basePath string) *exec.Cmd {
 
 func (s *Spec) genEnv(ctx context.Context, comList []string) *exec.Cmd {
 	cmdString := strings.Join(comList, ";")
-	//cmdString = fmt.Sprintf("'%s'", cmdString)
-	fmt.Printf("command: %s\n", cmdString)
 	cmd := exec.CommandContext(ctx, "bash", "-ce", cmdString)
 	var newEnv []string
 	for key, val := range s.Global.Env {


### PR DESCRIPTION
Adds two new magic variables:

__ref__: contains the ref of the event e.g. refs/heads/master
__branch__: contains the branch name of the event